### PR TITLE
use rc + arg to write

### DIFF
--- a/.npirc
+++ b/.npirc
@@ -1,0 +1,18 @@
+{
+ "targetUrl": {
+  "protocol": "http:",
+  "slashes": true,
+  "auth": null,
+  "host": "jquery.com",
+  "port": null,
+  "hostname": "jquery.com",
+  "hash": null,
+  "search": null,
+  "query": null,
+  "pathname": "/",
+  "path": "/",
+  "href": "http://jquery.com/"
+ },
+ "targetDir": "./test",
+ "proxyPort": "8000"
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@
   * `-u`, `--target-url` Specify url to proxy. Default currently set to http://jquery.com/ for example purposes
   * `-d`, `--target-dir` Specify directory containing files to inject. Default currently set to './test' for example purposes
   * `-p`, `--port` Specify port for proxy server to listen on. Default is 8000.
+  * `-c`, `--create-rc` Creates an RC file in the local dir. Prints + Prompts w/ diff. Default is false.

--- a/package.json
+++ b/package.json
@@ -18,9 +18,13 @@
   "homepage": "https://github.com/casecode/node-proxy-injector",
   "dependencies": {
     "cheerio": "^0.18.0",
+    "colors": "^1.0.3",
     "commander": "^2.6.0",
     "connect": "^3.3.4",
+    "diff": "^1.2.1",
     "livereload": "^0.3.4",
-    "q": "^1.1.2"
+    "q": "^1.1.2",
+    "rc": "^0.5.5",
+    "readline-sync": "^0.4.10"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 /*jshint node:true*/
 
+var appname = 'npi'; // .npirc
+var rc = require('rc');
+var rcfile = '.' + appname + 'rc';
 var program = require('commander');
 var http = require('http');
 var url = require('url');
-var path = require('path');
+var fs = require('fs');
 var connect = require('connect');
 var proxyInjector = require('./lib/proxy-injector');
 var livereload = require('livereload');
@@ -16,6 +19,7 @@ program
   .option('-u, --target-url [url]', 'The target url to proxy', 'http://jquery.com/')
   .option('-d, --target-dir [path]', 'The path of the target directory to watch', './test')
   .option('-p, --port <n>', 'The proxy port', parseInt, '8000')
+  .option('-c, --create-rc', 'Create .npirc file', false)
   .parse(process.argv);
 
 // resolve options args
@@ -25,15 +29,48 @@ if (targetUrl.substring(0, 4) !== "http") {
 }
 targetUrl = url.parse(targetUrl);
 
-var targetDir = path.resolve(__dirname, program.targetDir);
+var targetDir = program.targetDir;
 
-
-// Config options
-var options = {
+var config = { // defaults:
   targetUrl: targetUrl,
   targetDir: targetDir, // directory containing scripts and stylesheets for injection
   proxyPort: program.port // local proxy server port
 };
+
+// write rc or prompt w/ if already exist
+if (program.createRc) {
+  var writeConf = function () {
+    fs.writeFileSync(rcfile, JSON.stringify(config, 2, ' '));
+  };
+
+  if ( ! fs.existsSync(rcfile) ) writeConf();
+  else {
+    require('colors');
+    var prompt = require('readline-sync');
+    var diff = require('diff');
+
+    diff.diffJson(
+      JSON.parse(fs.readFileSync(rcfile).toString()),
+      config
+    ).forEach(function(part){
+      // green for additions, red for deletions
+      // grey for common parts
+      var color = part.added ? 'green' :
+        part.removed ? 'red' : 'grey';
+      process.stderr.write(part.value[color]);
+    });
+
+    console.log();
+
+    if (prompt.question('Overwrite? (y/n) :'.blue)
+      .toLowerCase() === 'y') writeConf();
+  }
+}
+
+// Config options
+var options = rc(appname, config);
+// note: defaults which are objects will be merged, not replaced
+// views: {foo:'bar'}
 
 var proxy = proxyInjector.createProxyServer(options);
 


### PR DESCRIPTION
hate the way this code looks but wanted to keep it in one place for assumed future refractors. works by adding a -c var to the command that will write an rc file and/or prompt if overwriting (w/ a printed diff). the rc is read (if it exists) and provides the base which the other cli args extend.

rc docs: https://www.npmjs.com/package/rc
